### PR TITLE
added downstream proxy support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/google/martian/v3 v3.3.2
 	github.com/rivo/tview v0.0.0-20230226195229-47e7db7885b4
 	github.com/rivo/uniseg v0.4.4 // indirect
-	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/net v0.7.0
 )

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ type Window func() (title string, content tview.Primitive)
 func main() {
 	// process command line flags
 	addr := flag.String("addr", "", "The bind address, default 0.0.0.0")
+	downstreamProxy := flag.String("proxy", "", "downstream proxy to use in URI format. example: socks5://127.0.0.1:9050. empty means no downstream proxy")
 	cert := flag.String("cert", "", "Path to a CA Certificate")
 	key := flag.String("key", "", "Path to the CA cert's private key")
 	port := flag.Uint("port", 0, "Listen port for the proxy, default 8080")
@@ -44,10 +45,11 @@ func main() {
 
 	// start the Martian proxy
 	config := &proxy.Config{
-		Addr: *addr,
-		Cert: *cert,
-		Key:  *key,
-		Port: *port,
+		Addr:  *addr,
+		Cert:  *cert,
+		Proxy: *downstreamProxy,
+		Key:   *key,
+		Port:  *port,
 	}
 
 	proxychan := make(chan modifier.Notification, 1024)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -18,8 +19,9 @@ import (
 
 // Config - struct that holds the proxy config
 type Config struct {
-	Port uint   // port to listen on, default 8080
-	Addr string // ip address to listen on, default 0.0.0.0
+	Port  uint   // port to listen on, default 8080
+	Addr  string // ip address to listen on, default 0.0.0.0
+	Proxy string // downstream proxy to use, optional.
 
 	Cert string // CA certificate
 	Key  string // key
@@ -59,6 +61,14 @@ func StartProxy(logger *modifier.Logger, config *Config) *martian.Proxy {
 		DisableCompression: true,
 	}
 	p.SetRoundTripper(tr)
+
+	if config.Proxy != "" {
+		proxyURL, err := url.Parse(config.Proxy)
+		if err != nil {
+			log.Printf("martian: error parsing upstream proxy URL: %v, skipping proxy\n", err)
+		}
+		p.SetDownstreamProxy(proxyURL)
+	}
 
 	var x509c *x509.Certificate
 	var priv interface{}


### PR DESCRIPTION
for some reason, Google calls it downstream instead of upstream (https://github.com/google/martian/blob/0f7e6797a04da412118541344bbe0d65945e24c9/proxy.go#L110). matter of perspective I guess :) 

addresses #9 